### PR TITLE
Add Buildozer wrapper for Python 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Press `SPACE` to jump. Avoid the pipes! Press `R` after a crash to restart.
 
 To convert this game into an Android APK you can use Kivy's Buildozer tool:
 
-1. Install buildozer and its dependencies.
+1. Install buildozer and its dependencies. If you are using Python 3.12 or
+   newer, run Buildozer via the included `buildozer_wrapper.py` script which
+   provides the deprecated `distutils` module from `setuptools`.
 2. Initialize a spec file:
    ```bash
    buildozer init

--- a/buildozer_wrapper.py
+++ b/buildozer_wrapper.py
@@ -1,0 +1,20 @@
+"""Run Buildozer with compatibility fixes for Python 3.12+.
+
+This script ensures the deprecated ``distutils`` module is available to
+Buildozer by providing it from ``setuptools`` when running under
+Python 3.12 or newer.
+"""
+
+import sys
+
+try:
+    # Preload distutils from setuptools for Python 3.12+
+    import distutils  # noqa: F401
+except ModuleNotFoundError:
+    import setuptools
+    sys.modules['distutils'] = setuptools._distutils
+
+from buildozer.scripts.client import main
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- create `buildozer_wrapper.py` to provide `distutils` via setuptools
- update README with instructions for using the wrapper with Python 3.12+

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843e30d8a3c832ca0c8776831b6b7dd